### PR TITLE
fix typo in user-service controller

### DIFF
--- a/user-service/src/app.controller.ts
+++ b/user-service/src/app.controller.ts
@@ -6,7 +6,7 @@ import { AppService } from './app.service';
 export class AppController {
     constructor(private service: AppService) {}
 
-    @MessagePattern('find_all_user')
+    @MessagePattern('find_all_users')
     findAll() {
         return this.service.findAll();
     }


### PR DESCRIPTION


* [`user-service/src/app.controller.ts`](diffhunk://#diff-c171c533b76aa0e77aa47383451dcdf9d4f93175b5eaaa056b5c1fc4d8fa3b4aL9-R9): Corrected the message pattern from 'find_all_user' to 'find_all_users'.