### PR TITLE
rmq module setup for users queue

### DIFF
--- a/apps/gateway/src/rmq-client/rmq-client.module.ts
+++ b/apps/gateway/src/rmq-client/rmq-client.module.ts
@@ -1,4 +1,40 @@
-import { Module } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+export interface RmqClientModuleOptions {
+  name: string;
+  queue: string;
+}
 
 @Module({})
-export class RmqClientModule {}
+export class RmqClientModule {
+  static forRootAsync(options: RmqClientModuleOptions): DynamicModule {
+    return {
+      module: RmqClientModule,
+      imports: [
+        ClientsModule.registerAsync([
+          {
+            name: options.name,
+            imports: [ConfigModule],
+            useFactory: (configService: ConfigService) => ({
+              transport: Transport.RMQ,
+              options: {
+                urls: [
+                  configService.get<string>('RABBITMQ_URL') ??
+                    'amqp://rabbitmq:5672',
+                ],
+                queue: options.queue,
+                queueOptions: {
+                  durable: false,
+                },
+              },
+            }),
+            inject: [ConfigService],
+          },
+        ]),
+      ],
+      exports: [ClientsModule],
+    };
+  }
+}

--- a/apps/gateway/src/users/users.module.ts
+++ b/apps/gateway/src/users/users.module.ts
@@ -1,8 +1,15 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersResolver } from './users.resolver';
+import { RmqClientModule } from '../rmq-client/rmq-client.module';
 
 @Module({
+  imports: [
+    RmqClientModule.forRootAsync({
+      name: 'USERS_SERVICE',
+      queue: 'users_queue',
+    }),
+  ],
   providers: [UsersResolver, UsersService],
 })
 export class UsersModule {}

--- a/apps/users/src/main.ts
+++ b/apps/users/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
       transport: Transport.RMQ,
       options: {
         urls: [process.env.RABBITMQ_URL || 'amqp://localhost:5672'],
-        queue: 'user_queue',
+        queue: 'users_queue',
         queueOptions: { durable: false },
       },
     },


### PR DESCRIPTION
This pull request includes significant changes to the RabbitMQ client module and its integration into the users module. The most important changes include the addition of a dynamic module for RabbitMQ client configuration, the integration of this module into the users module, and a minor update to the queue name in the main application file.

### RabbitMQ Client Module Enhancements:
* [`apps/gateway/src/rmq-client/rmq-client.module.ts`](diffhunk://#diff-889f6e653637a2d3e716aae42b818a3de082653ac4fe827b33b823b4d993ed98L1-R40): Introduced a new `RmqClientModule` with a `forRootAsync` method that allows dynamic configuration of RabbitMQ clients using `ClientsModule` and `ConfigService`.

### Integration with Users Module:
* [`apps/gateway/src/users/users.module.ts`](diffhunk://#diff-5db6237e71a7f234f94626fb67430dea0734aedcc259c24278ab314d8a47d6ecR4-R12): Integrated the newly created `RmqClientModule` into the users module with specific configuration for the `USERS_SERVICE` and `users_queue`.

### Configuration Updates:
* [`apps/users/src/main.ts`](diffhunk://#diff-f01db1250e8d18815225c46f4df5edc3dc40a2e4b1f28b11c860aab4f732a4d1L12-R12): Updated the RabbitMQ queue name from `user_queue` to `users_queue` to match the new configuration.